### PR TITLE
Fix for ES WARN "[types removal] Specifying types in bulk requests is deprecated."

### DIFF
--- a/src/main/java/org/codelibs/elasticsearch/client/action/HttpBulkAction.java
+++ b/src/main/java/org/codelibs/elasticsearch/client/action/HttpBulkAction.java
@@ -39,6 +39,7 @@ import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.common.xcontent.json.JsonXContent;
 import org.elasticsearch.index.VersionType;
+import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.index.seqno.SequenceNumbers;
 
 public class HttpBulkAction extends HttpAction {
@@ -120,7 +121,9 @@ public class HttpBulkAction extends HttpAction {
         final String opType = request.opType().getLowercase();
         buf.append("{\"").append(opType).append("\":{");
         appendStr(buf, "_index", request.index());
-        if (request.type() != null) {
+        if (request.type() != null &&
+                // workaround fix for org.elasticsearch.action.index.IndexRequest.type()
+                !request.type().equals(MapperService.SINGLE_MAPPING_NAME)) {
             appendStr(buf.append(','), "_type", request.type());
         }
         if (request.id() != null) {

--- a/src/main/java/org/codelibs/elasticsearch/client/action/HttpBulkAction.java
+++ b/src/main/java/org/codelibs/elasticsearch/client/action/HttpBulkAction.java
@@ -39,7 +39,6 @@ import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.common.xcontent.json.JsonXContent;
 import org.elasticsearch.index.VersionType;
-import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.index.seqno.SequenceNumbers;
 
 public class HttpBulkAction extends HttpAction {
@@ -123,7 +122,7 @@ public class HttpBulkAction extends HttpAction {
         appendStr(buf, "_index", request.index());
         if (request.type() != null &&
                 // workaround fix for org.elasticsearch.action.index.IndexRequest.type()
-                !request.type().equals(MapperService.SINGLE_MAPPING_NAME)) {
+                !request.type().equals("_doc")) {
             appendStr(buf.append(','), "_type", request.type());
         }
         if (request.id() != null) {


### PR DESCRIPTION
Workaround for IndexRequest.type() :
https://github.com/elastic/elasticsearch/blob/7.6/server/src/main/java/org/elasticsearch/action/index/IndexRequest.java#L276